### PR TITLE
Remove an unneeded TODO

### DIFF
--- a/nanosimh/simulate.py
+++ b/nanosimh/simulate.py
@@ -531,10 +531,6 @@ def extract_read(dna_type, length):
         while True:
             new_read = ""
             ref_pos = random.randint(0, genome_len)
-            #
-            # Karel:
-            # todo: check if this code is correct, Python dict might not have a well defined order of keys
-            #
             for key in seq_len.keys():
                 if ref_pos + length < seq_len[key]:
                     new_read = seq_dict[key][ref_pos:ref_pos + length]


### PR DESCRIPTION
This code is fine; dict iteration order is guaranteed to be stable as long as the dict is not modified, and this was the case even back in Python 2. See https://docs.python.org/2/library/stdtypes.html#dict.items:

> If items(), keys(), values(), iteritems(), iterkeys(), and itervalues() are called with no intervening modifications to the dictionary, the lists will directly correspond.

(Also, even if dict iteration order was unstable here, and the first `key` value you got in the `for key in seq_len.keys():` loop was different on each pass through the `while True:` loop, it seems to me that that would still be fine?)